### PR TITLE
Lazy-load Supabase client to prevent build-time env errors

### DIFF
--- a/app/AuthForm.tsx
+++ b/app/AuthForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { supabase } from "../lib/supabaseClient";
+import { getSupabaseClient } from "../lib/supabaseClient";
 
 type AuthMode = "login" | "signup";
 
@@ -19,12 +19,20 @@ export default function AuthForm({ mode }: { mode: AuthMode }) {
       setError("PIN must be exactly 4 digits");
       return;
     }
-    const authFn = mode === "signup" ? supabase.auth.signUp : supabase.auth.signInWithPassword;
-    const { error } = await authFn({ email, password: pin });
-    if (error) {
-      setError(error.message);
-    } else {
-      router.push("/");
+    try {
+      const supabase = getSupabaseClient();
+      const authFn =
+        mode === "signup"
+          ? supabase.auth.signUp
+          : supabase.auth.signInWithPassword;
+      const { error } = await authFn({ email, password: pin });
+      if (error) {
+        setError(error.message);
+      } else {
+        router.push("/");
+      }
+    } catch (e) {
+      setError((e as Error).message);
     }
   };
 

--- a/app/CareerNavigator.tsx
+++ b/app/CareerNavigator.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { supabase } from "../lib/supabaseClient";
+import { getSupabaseClient } from "../lib/supabaseClient";
 
 // --- Minimal helpers -------------------------------------------------------
 const uid = () => Math.random().toString(36).slice(2, 10);
@@ -278,6 +278,7 @@ function asMarkdown(j) {
 function Shell({ step, setStep, saveState, children }) {
   const [email, setEmail] = useState<string | null>(null);
   useEffect(() => {
+    const supabase = getSupabaseClient();
     supabase.auth.getUser().then(({ data: { user } }) => setEmail(user?.email ?? null));
   }, []);
   const stepToPhase = (s) => (s <= 4 ? "Phase 1" : s <= 6 ? "Phase 2" : "Phase 3");
@@ -700,6 +701,7 @@ export default function CareerNavigator() {
   });
 
   useEffect(() => {
+    const supabase = getSupabaseClient();
     supabase.from('journeys').select('id').limit(1)
       .then(({ error }) => {
         if (error) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import type { Session } from "@supabase/supabase-js";
 import CareerNavigatorLoader from "./CareerNavigatorLoader";
 import AuthForm from "./AuthForm";
-import { supabase } from "../lib/supabaseClient";
+import { getSupabaseClient } from "../lib/supabaseClient";
 
 export default function Page() {
   const [session, setSession] = useState<Session | null>(null);
@@ -12,6 +12,7 @@ export default function Page() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    const supabase = getSupabaseClient();
     supabase.auth.getSession().then(({ data }) => {
       setSession(data.session);
       setLoading(false);

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,10 +1,15 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+let client: SupabaseClient | null = null;
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error('Missing Supabase URL or anon key. Check your environment variables.');
+export function getSupabaseClient(): SupabaseClient {
+  if (!client) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    if (!url || !anonKey) {
+      throw new Error('Missing Supabase URL or anon key. Check your environment variables.');
+    }
+    client = createClient(url, anonKey);
+  }
+  return client;
 }
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- Lazy initialize Supabase client to avoid accessing env vars during Next.js build
- Update auth and pages to obtain client within effects or events

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb274c19ec8322beaf42d6f33b388f