### PR TITLE
Lazy-load Supabase client to prevent build-time env errors

### DIFF
--- a/app/AuthForm.tsx
+++ b/app/AuthForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { supabase } from "../lib/supabaseClient";
+import { getSupabaseClient } from "../lib/supabaseClient";
 
 type AuthMode = "login" | "signup";
 
@@ -19,12 +19,20 @@ export default function AuthForm({ mode }: { mode: AuthMode }) {
       setError("PIN must be exactly 4 digits");
       return;
     }
-    const authFn = mode === "signup" ? supabase.auth.signUp : supabase.auth.signInWithPassword;
-    const { error } = await authFn({ email, password: pin });
-    if (error) {
-      setError(error.message);
-    } else {
-      router.push("/");
+    try {
+      const supabase = getSupabaseClient();
+      const authFn =
+        mode === "signup"
+          ? supabase.auth.signUp
+          : supabase.auth.signInWithPassword;
+      const { error } = await authFn({ email, password: pin });
+      if (error) {
+        setError(error.message);
+      } else {
+        router.push("/");
+      }
+    } catch (e) {
+      setError((e as Error).message);
     }
   };
 

--- a/app/CareerNavigator.tsx
+++ b/app/CareerNavigator.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { supabase } from "../lib/supabaseClient";
+import { getSupabaseClient } from "../lib/supabaseClient";
 
 // --- Minimal helpers -------------------------------------------------------
 const uid = () => Math.random().toString(36).slice(2, 10);
@@ -278,7 +278,14 @@ function asMarkdown(j) {
 function Shell({ step, setStep, saveState, children }) {
   const [email, setEmail] = useState<string | null>(null);
   useEffect(() => {
-    supabase.auth.getUser().then(({ data: { user } }) => setEmail(user?.email ?? null));
+    try {
+      const supabase = getSupabaseClient();
+      supabase.auth
+        .getUser()
+        .then(({ data: { user } }) => setEmail(user?.email ?? null));
+    } catch (e) {
+      console.error(e);
+    }
   }, []);
   const stepToPhase = (s) => (s <= 4 ? "Phase 1" : s <= 6 ? "Phase 2" : "Phase 3");
   return (
@@ -700,14 +707,22 @@ export default function CareerNavigator() {
   });
 
   useEffect(() => {
-    supabase.from('journeys').select('id').limit(1)
-      .then(({ error }) => {
-        if (error) {
-          console.error('Supabase connection error', error);
-        } else {
-          console.log('Connected to Supabase');
-        }
-      });
+    try {
+      const supabase = getSupabaseClient();
+      supabase
+        .from('journeys')
+        .select('id')
+        .limit(1)
+        .then(({ error }) => {
+          if (error) {
+            console.error('Supabase connection error', error);
+          } else {
+            console.log('Connected to Supabase');
+          }
+        });
+    } catch (e) {
+      console.error(e);
+    }
   }, []);
 
   // Autosave to localStorage

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,10 +1,30 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+let client: SupabaseClient | null = null;
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error('Missing Supabase URL or anon key. Check your environment variables.');
+export function getSupabaseClient(): SupabaseClient {
+  if (!client) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    if (!url || !anonKey) {
+      throw new Error('Missing Supabase URL or anon key. Check your environment variables.');
+    }
+
+    // Validate URL format to provide clearer errors when variables are swapped
+    try {
+      // Throws if url is not a valid URL (e.g. the anon key by mistake)
+      // eslint-disable-next-line no-new
+      new URL(url);
+    } catch {
+      if (/^https?:\/\//i.test(anonKey)) {
+        throw new Error(
+          'Invalid Supabase URL. It looks like the URL and anon key might be swapped.'
+        );
+      }
+      throw new Error('Invalid Supabase URL. Check NEXT_PUBLIC_SUPABASE_URL.');
+    }
+
+    client = createClient(url, anonKey);
+  }
+  return client;
 }
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- Lazy initialize Supabase client to avoid accessing env vars during Next.js build
- Catch missing Supabase configuration at runtime and surface the error instead of crashing
- Guard remaining Supabase interactions with try/catch
- Validate Supabase URL format to detect swapped environment variables

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb274c19ec8322beaf42d6f33b388f