### PR TITLE
Lazy-load Supabase client to prevent build-time env errors

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,5 +1,19 @@
+import Link from "next/link";
 import AuthForm from "../AuthForm";
 
 export default function LoginPage() {
-  return <AuthForm mode="login" />;
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-gray-900 via-gray-800 to-black text-white">
+      <div className="w-full max-w-md p-8 space-y-6 bg-gray-800/70 backdrop-blur rounded-lg shadow-xl">
+        <h1 className="text-3xl font-bold text-center">Welcome Back</h1>
+        <AuthForm mode="login" />
+        <p className="text-sm text-center text-gray-300">
+          Don't have an account?{" "}
+          <Link href="/signup" className="text-indigo-400 underline">
+            Sign up
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
 }

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,5 +1,19 @@
+import Link from "next/link";
 import AuthForm from "../AuthForm";
 
 export default function SignupPage() {
-  return <AuthForm mode="signup" />;
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-blue-50 via-teal-50 to-emerald-100">
+      <div className="w-full max-w-md p-8 space-y-6 bg-white/90 backdrop-blur rounded-lg shadow">
+        <h1 className="text-3xl font-bold text-center text-gray-800">Create Account</h1>
+        <AuthForm mode="signup" />
+        <p className="text-sm text-center text-gray-700">
+          Already have an account?{" "}
+          <Link href="/login" className="text-blue-600 underline">
+            Log in
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
 }

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,10 +1,30 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+let client: SupabaseClient | null = null;
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error('Missing Supabase URL or anon key. Check your environment variables.');
+export function getSupabaseClient(): SupabaseClient {
+  if (!client) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    if (!url || !anonKey) {
+      throw new Error('Missing Supabase URL or anon key. Check your environment variables.');
+    }
+
+    // Validate URL format to provide clearer errors when variables are swapped
+    try {
+      // Throws if url is not a valid URL (e.g. the anon key by mistake)
+      // eslint-disable-next-line no-new
+      new URL(url);
+    } catch {
+      if (/^https?:\/\//i.test(anonKey)) {
+        throw new Error(
+          'Invalid Supabase URL. It looks like the URL and anon key might be swapped.'
+        );
+      }
+      throw new Error('Invalid Supabase URL. Check NEXT_PUBLIC_SUPABASE_URL.');
+    }
+
+    client = createClient(url, anonKey);
+  }
+  return client;
 }
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- Lazy initialize Supabase client to avoid accessing env vars during Next.js build
- Catch missing Supabase configuration at runtime and surface the error instead of crashing
- Guard remaining Supabase interactions with try/catch
- Validate Supabase URL format to detect swapped environment variables
- Fix signup flow by calling Supabase auth methods directly and automatically signing users in
- Add navigation links between dedicated login and signup pages
- Allow 4-digit PINs by padding to Supabase's 6-char password requirement
- Redesign login and signup pages with distinct themes and tailored form styling
- Sign up directly through the public client, removing the service-role API and extra env var
- Remove demo footer and add a logout button beside the signed-in email
- Limit stored experiences to 15 and update all related copy

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb274c19ec8322beaf42d6f33b388f