### PR TITLE
feat: add voice recording for context and impact

### DIFF
--- a/app/api/transcribe/route.ts
+++ b/app/api/transcribe/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import OpenAI from "openai";
+
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  try {
+    const formData = await req.formData();
+    const file = formData.get("file") as File | null;
+    const language = formData.get("language") as string | null;
+    if (!file) {
+      return NextResponse.json({ error: "Missing file" }, { status: 400 });
+    }
+    const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    const audioFile = new File([await file.arrayBuffer()], file.name, {
+      type: file.type,
+    });
+    const transcription = await client.audio.transcriptions.create({
+      file: audioFile,
+      model: "whisper-1",
+      language: language || undefined,
+    });
+    return NextResponse.json({ text: transcription.text });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Transcription failed" }, { status: 500 });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,23 +11,21 @@
     "check:supabase": "node scripts/checkSupabase.mjs"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.45.0",
     "next": "^15.5.1-canary.24",
+    "openai": "^4.0.0",
     "react": "18.3.1",
-    "react-dom": "18.3.1",
-    "@supabase/supabase-js": "^2.45.0"
+    "react-dom": "18.3.1"
   },
   "devDependencies": {
-    "@types/node": "^24.3.0",
-    "@types/react": "^19.1.12",
-    "@types/react-dom": "^19.1.9",
+    "@types/node": "file:types/node",
+    "@types/react": "file:types/react",
+    "@types/react-dom": "file:types/react-dom",
     "autoprefixer": "10.4.19",
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.4",
     "postcss": "8.4.38",
     "tailwindcss": "3.4.7",
-   "typescript": "^5",
-    "@types/react": "file:types/react",
-    "@types/react-dom": "file:types/react-dom",
-    "@types/node": "file:types/node"
+    "typescript": "^5"
   }
 }


### PR DESCRIPTION
## Summary
- allow voice-based entry for context and impact with recording controls, progress indicator, and transcript editing
- add transcription API route using OpenAI Whisper and wire up environment key
- remove committed `.env.local` file and rely on `.gitignore` to keep secrets out of version control
- reposition Phase 3 record button above text areas and style with dark background, yellow hover, white text, and microphone icon
- restyle Phase 3 "Weiter zu Phase 4" button to match record button and give it more vertical spacing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd79d1c6048322b5ebc5e9f4c0957c