### PR TITLE
feat: add voice recording for context and impact

### DIFF
--- a/app/CareerNavigator.tsx
+++ b/app/CareerNavigator.tsx
@@ -130,6 +130,95 @@ function DraggableList({ items, setItems, render, itemKey }) {
   );
 }
 
+// --- Voice-enabled textarea -------------------------------------------------
+function VoiceTextarea({ value, onChange, placeholder }) {
+  const [recording, setRecording] = useState(false);
+  const [transcribing, setTranscribing] = useState(false);
+  const [lastTranscript, setLastTranscript] = useState("");
+  const mediaRef = useRef(null);
+  const chunksRef = useRef([]);
+
+  const toggle = async () => {
+    if (recording) {
+      mediaRef.current?.stop();
+      return;
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const mr = new MediaRecorder(stream);
+      mediaRef.current = mr;
+      chunksRef.current = [];
+      mr.ondataavailable = (e) => chunksRef.current.push(e.data);
+      mr.onstop = () => {
+        stream.getTracks().forEach((t) => t.stop());
+        const blob = new Blob(chunksRef.current, { type: "audio/webm" });
+        send(blob);
+      };
+      mr.start();
+      setRecording(true);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const send = async (blob) => {
+    setRecording(false);
+    setTranscribing(true);
+    const fd = new FormData();
+    fd.append("file", blob, "audio.webm");
+    try {
+      const res = await fetch("/api/transcribe", { method: "POST", body: fd });
+      const data = await res.json();
+      if (data.text) {
+        setLastTranscript(data.text);
+        const next = value ? value + " " + data.text : data.text;
+        onChange(next);
+      }
+    } catch (e) {
+      console.error(e);
+    }
+    setTranscribing(false);
+  };
+
+  const deleteLast = () => {
+    if (!lastTranscript) return;
+    if (value.endsWith(lastTranscript)) {
+      const next = value.slice(0, -lastTranscript.length).trim();
+      onChange(next);
+    }
+    setLastTranscript("");
+  };
+
+  return (
+    <div>
+      <div className="mb-1 flex justify-end items-center gap-2">
+        {recording && <span className="text-small text-neutrals-600">Recording…</span>}
+        {transcribing && <span className="text-small text-neutrals-600">Transcribing…</span>}
+        {!recording && lastTranscript && (
+          <button type="button" onClick={deleteLast} className="px-2 py-1 rounded-xl border">
+            Delete last
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={toggle}
+          className="flex items-center gap-1 px-2 py-1 rounded-xl bg-[#1D252A] text-white hover:bg-primary-500 hover:text-neutrals-900"
+        >
+          <span>🎙️</span>
+          {recording ? "Stop" : "Record"}
+        </button>
+      </div>
+      <textarea
+        className="w-full rounded-2xl border border-accent-700 p-3 mb-2"
+        rows={2}
+        placeholder={placeholder}
+        value={value}
+        onChange={(ev) => onChange(ev.target.value)}
+      />
+    </div>
+  );
+}
+
 // --- Shell -----------------------------------------------------------------
 function Shell({ step, setStep, saveState, children }) {
   const [email, setEmail] = useState<string | null>(null);
@@ -302,8 +391,14 @@ function Phase1({ journey, setJourney, onNext, setSaveState }) {
         </ul>
         <div className="mt-2 text-small text-neutrals-500">{exps.length}/15</div>
       </section>
-      <div className="flex justify-end">
-        <button onClick={onNext} disabled={!canNext} className="px-3 py-2 rounded-xl bg-primary-500 text-neutrals-0 disabled:opacity-40">Weiter zu Phase 2</button>
+      <div className="flex justify-end mt-6">
+        <button
+          onClick={onNext}
+          disabled={!canNext}
+          className="px-3 py-2 rounded-xl bg-[#1D252A] text-white hover:bg-primary-500 hover:text-neutrals-900 disabled:opacity-40"
+        >
+          Weiter zu Phase 2
+        </button>
       </div>
     </div>
   );
@@ -357,9 +452,15 @@ function Phase2({ journey, setJourney, onNext, onBack, setSaveState }) {
           itemKey={(e) => e.id}
         />
       </section>
-      <div className="flex justify-between">
+      <div className="flex justify-between mt-6">
         <button onClick={onBack} className="px-3 py-2 rounded-xl border">Zurück</button>
-        <button onClick={onNext} disabled={!canNext} className="px-3 py-2 rounded-xl bg-primary-500 text-neutrals-0 disabled:opacity-40">Weiter zu Phase 3</button>
+        <button
+          onClick={onNext}
+          disabled={!canNext}
+          className="px-3 py-2 rounded-xl bg-[#1D252A] text-white hover:bg-primary-500 hover:text-neutrals-900 disabled:opacity-40"
+        >
+          Weiter zu Phase 3
+        </button>
       </div>
     </div>
   );
@@ -367,7 +468,11 @@ function Phase2({ journey, setJourney, onNext, onBack, setSaveState }) {
 
 // --- Phase 3 ---------------------------------------------------
 function Phase3({ journey, setJourney, onNext, onBack, setSaveState }) {
-  const top = (journey.top7Ids || [])
+  const topIds =
+    journey.top7Ids && journey.top7Ids.length > 0
+      ? journey.top7Ids
+      : (journey.ranking || []).slice(0, 7);
+  const top = topIds
     .map((id) => (journey.experiences || []).find((e) => e.id === id))
     .filter(Boolean);
   const stories = journey.stories || {};
@@ -423,27 +528,29 @@ function Phase3({ journey, setJourney, onNext, onBack, setSaveState }) {
           {top.map((e, idx) => (
             <div key={e.id} className="border border-accent-700 rounded-2xl p-3">
               <div className="font-medium mb-2">{idx + 1}. {e.title}</div>
-              <textarea
-                className="w-full rounded-2xl border border-accent-700 p-3 mb-2"
-                rows={2}
+              <VoiceTextarea
                 placeholder="Kontext"
                 value={stories[e.id]?.context || ""}
-                onChange={(ev) => update(e.id, "context", ev.target.value)}
+                onChange={(v) => update(e.id, "context", v)}
               />
-              <textarea
-                className="w-full rounded-2xl border border-accent-700 p-3"
-                rows={2}
+              <VoiceTextarea
                 placeholder="Impact"
                 value={stories[e.id]?.impact || ""}
-                onChange={(ev) => update(e.id, "impact", ev.target.value)}
+                onChange={(v) => update(e.id, "impact", v)}
               />
             </div>
           ))}
         </div>
       </section>
-      <div className="flex justify-between">
+      <div className="flex justify-between mt-6">
         <button onClick={onBack} className="px-3 py-2 rounded-xl border">Zurück</button>
-        <button onClick={handleNext} disabled={!canNext} className="px-3 py-2 rounded-xl bg-primary-500 text-neutrals-0 disabled:opacity-40">Weiter zu Phase 4</button>
+        <button
+          onClick={handleNext}
+          disabled={!canNext}
+          className="px-3 py-2 rounded-xl bg-[#1D252A] text-white hover:bg-primary-500 hover:text-neutrals-900 disabled:opacity-40"
+        >
+          Weiter zu Phase 4
+        </button>
       </div>
     </div>
   );
@@ -457,9 +564,14 @@ function Phase4({ onNext, onBack }) {
         <h2 className="text-lg font-semibold mb-2">Phase 4: AI‑Analyse</h2>
         <p className="text-body text-neutrals-600">Die Analyse und Clusterung der Erfahrungen wird später durch einen externen AI‑Service durchgeführt.</p>
       </section>
-      <div className="flex justify-between">
+      <div className="flex justify-between mt-6">
         <button onClick={onBack} className="px-3 py-2 rounded-xl border">Zurück</button>
-        <button onClick={onNext} className="px-3 py-2 rounded-xl bg-primary-500 text-neutrals-0">Weiter zu Phase 5</button>
+        <button
+          onClick={onNext}
+          className="px-3 py-2 rounded-xl bg-[#1D252A] text-white hover:bg-primary-500 hover:text-neutrals-900"
+        >
+          Weiter zu Phase 5
+        </button>
       </div>
     </div>
   );
@@ -503,7 +615,7 @@ function Phase5({ journey, setJourney, onBack, setSaveState }) {
           onChange={(e) => updateField('current', e.target.value)}
         />
       </section>
-      <div className="flex justify-start">
+      <div className="flex justify-start mt-6">
         <button onClick={onBack} className="px-3 py-2 rounded-xl border">Zurück</button>
       </div>
     </div>
@@ -577,7 +689,12 @@ export default function CareerNavigator() {
             <li>Hintergrundinfos</li>
           </ol>
           <div className="flex items-center gap-2">
-            <button onClick={() => setStep(1)} className="px-4 py-2 rounded-xl bg-primary-500 text-neutrals-0">Starten</button>
+            <button
+              onClick={() => setStep(1)}
+              className="px-4 py-2 rounded-xl bg-[#1D252A] text-white hover:bg-primary-500 hover:text-neutrals-900"
+            >
+              Starten
+            </button>
             <button onClick={reset} className="px-4 py-2 rounded-xl border">Zurücksetzen</button>
           </div>
         </section>

--- a/app/api/transcribe/route.ts
+++ b/app/api/transcribe/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import OpenAI from "openai";
+
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  try {
+    const formData = await req.formData();
+    const file = formData.get("file") as File | null;
+    const language = formData.get("language") as string | null;
+    if (!file) {
+      return NextResponse.json({ error: "Missing file" }, { status: 400 });
+    }
+    const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    const audioFile = new File([await file.arrayBuffer()], file.name, {
+      type: file.type,
+    });
+    const transcription = await client.audio.transcriptions.create({
+      file: audioFile,
+      model: "whisper-1",
+      language: language || undefined,
+    });
+    return NextResponse.json({ text: transcription.text });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Transcription failed" }, { status: 500 });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,23 +11,21 @@
     "check:supabase": "node scripts/checkSupabase.mjs"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.45.0",
     "next": "^15.5.1-canary.24",
+    "openai": "^4.0.0",
     "react": "18.3.1",
-    "react-dom": "18.3.1",
-    "@supabase/supabase-js": "^2.45.0"
+    "react-dom": "18.3.1"
   },
   "devDependencies": {
-    "@types/node": "^24.3.0",
-    "@types/react": "^19.1.12",
-    "@types/react-dom": "^19.1.9",
+    "@types/node": "file:types/node",
+    "@types/react": "file:types/react",
+    "@types/react-dom": "file:types/react-dom",
     "autoprefixer": "10.4.19",
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.4",
     "postcss": "8.4.38",
     "tailwindcss": "3.4.7",
-   "typescript": "^5",
-    "@types/react": "file:types/react",
-    "@types/react-dom": "file:types/react-dom",
-    "@types/node": "file:types/node"
+    "typescript": "^5"
   }
 }


### PR DESCRIPTION
## Summary
- allow voice-based entry for context and impact with recording controls, progress indicator, and transcript editing
- add transcription API route using OpenAI Whisper and wire up environment key
- remove committed `.env.local` file and rely on `.gitignore` to keep secrets out of version control
- reposition Phase 3 record button above text areas and style with dark background, yellow hover, white text, and microphone icon
- restyle Phase 3 "Weiter zu Phase 4" button to match record button and give it more vertical spacing
- add spacing above navigation buttons and apply dark/yellow styling to all forward navigation buttons

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd79d1c6048322b5ebc5e9f4c0957c