### PR TITLE
feat: add voice recording for context and impact

### DIFF
--- a/app/api/transcribe/route.ts
+++ b/app/api/transcribe/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import OpenAI from "openai";
+
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  try {
+    const formData = await req.formData();
+    const file = formData.get("file") as File | null;
+    const language = formData.get("language") as string | null;
+    if (!file) {
+      return NextResponse.json({ error: "Missing file" }, { status: 400 });
+    }
+    const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    const audioFile = new File([await file.arrayBuffer()], file.name, {
+      type: file.type,
+    });
+    const transcription = await client.audio.transcriptions.create({
+      file: audioFile,
+      model: "whisper-1",
+      language: language || undefined,
+    });
+    return NextResponse.json({ text: transcription.text });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Transcription failed" }, { status: 500 });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,23 +11,22 @@
     "check:supabase": "node scripts/checkSupabase.mjs"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.45.0",
     "next": "^15.5.1-canary.24",
+    "openai": "^4.0.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "@supabase/supabase-js": "^2.45.0"
+    "react-markdown": "^9.0.0"
   },
   "devDependencies": {
-    "@types/node": "^24.3.0",
-    "@types/react": "^19.1.12",
-    "@types/react-dom": "^19.1.9",
+    "@types/node": "^20.11.30",
+    "@types/react": "^18.2.45",
+    "@types/react-dom": "^18.2.18",
     "autoprefixer": "10.4.19",
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.4",
     "postcss": "8.4.38",
     "tailwindcss": "3.4.7",
-   "typescript": "^5",
-    "@types/react": "file:types/react",
-    "@types/react-dom": "file:types/react-dom",
-    "@types/node": "file:types/node"
+    "typescript": "^5"
   }
 }


### PR DESCRIPTION
## Summary
- add voice-enabled textareas with microphone control that record, transcribe via Whisper, and let users append or delete segments
- create `/api/transcribe` route using OpenAI to convert uploaded audio to text
- analyze saved experiences through n8n using only user and journey IDs, rendering the webhook result as Markdown
- ensure Phase 3 always shows saved top-seven stories by deriving them from stored stories when ranking data is missing
- replace local type stubs with published `@types` packages
- parse n8n webhook arrays and display their `output` field as formatted Markdown in Phase 4
- style Phase 4 Markdown headings with tailored classes so headers render correctly
- expand Phase 4 paragraph spacing so breaks are wider than single line jumps

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd79d1c6048322b5ebc5e9f4c0957c