### PR TITLE
feat: add voice recording for context and impact

### DIFF
--- a/app/CareerNavigator.tsx
+++ b/app/CareerNavigator.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
 import { createClient } from "@/utils/supabase/client";
 
 // --- Minimal helpers -------------------------------------------------------
@@ -127,6 +128,95 @@ function DraggableList({ items, setItems, render, itemKey }) {
         </li>
       ))}
     </ul>
+  );
+}
+
+// --- Voice-enabled textarea -------------------------------------------------
+function VoiceTextarea({ value, onChange, placeholder }) {
+  const [recording, setRecording] = useState(false);
+  const [transcribing, setTranscribing] = useState(false);
+  const [lastTranscript, setLastTranscript] = useState("");
+  const mediaRef = useRef(null);
+  const chunksRef = useRef([]);
+
+  const toggle = async () => {
+    if (recording) {
+      mediaRef.current?.stop();
+      return;
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const mr = new MediaRecorder(stream);
+      mediaRef.current = mr;
+      chunksRef.current = [];
+      mr.ondataavailable = (e) => chunksRef.current.push(e.data);
+      mr.onstop = () => {
+        stream.getTracks().forEach((t) => t.stop());
+        const blob = new Blob(chunksRef.current, { type: "audio/webm" });
+        send(blob);
+      };
+      mr.start();
+      setRecording(true);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const send = async (blob) => {
+    setRecording(false);
+    setTranscribing(true);
+    const fd = new FormData();
+    fd.append("file", blob, "audio.webm");
+    try {
+      const res = await fetch("/api/transcribe", { method: "POST", body: fd });
+      const data = await res.json();
+      if (data.text) {
+        setLastTranscript(data.text);
+        const next = value ? value + " " + data.text : data.text;
+        onChange(next);
+      }
+    } catch (e) {
+      console.error(e);
+    }
+    setTranscribing(false);
+  };
+
+  const deleteLast = () => {
+    if (!lastTranscript) return;
+    if (value.endsWith(lastTranscript)) {
+      const next = value.slice(0, -lastTranscript.length).trim();
+      onChange(next);
+    }
+    setLastTranscript("");
+  };
+
+  return (
+    <div>
+      <div className="mb-1 flex justify-end items-center gap-2">
+        {recording && <span className="text-small text-neutrals-600">Recording…</span>}
+        {transcribing && <span className="text-small text-neutrals-600">Transcribing…</span>}
+        {!recording && lastTranscript && (
+          <button type="button" onClick={deleteLast} className="px-2 py-1 rounded-xl border">
+            Delete last
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={toggle}
+          className="flex items-center gap-1 px-2 py-1 rounded-xl bg-[#1D252A] text-white hover:bg-primary-500 hover:text-neutrals-900"
+        >
+          <span>🎙️</span>
+          {recording ? "Stop" : "Record"}
+        </button>
+      </div>
+      <textarea
+        className="w-full rounded-2xl border border-accent-700 p-3 mb-2"
+        rows={2}
+        placeholder={placeholder}
+        value={value}
+        onChange={(ev) => onChange(ev.target.value)}
+      />
+    </div>
   );
 }
 
@@ -302,8 +392,14 @@ function Phase1({ journey, setJourney, onNext, setSaveState }) {
         </ul>
         <div className="mt-2 text-small text-neutrals-500">{exps.length}/15</div>
       </section>
-      <div className="flex justify-end">
-        <button onClick={onNext} disabled={!canNext} className="px-3 py-2 rounded-xl bg-primary-500 text-neutrals-0 disabled:opacity-40">Weiter zu Phase 2</button>
+      <div className="flex justify-end pt-8">
+        <button
+          onClick={onNext}
+          disabled={!canNext}
+          className="px-3 py-2 rounded-xl bg-[#1D252A] text-white hover:bg-primary-500 hover:text-neutrals-900 disabled:opacity-40"
+        >
+          Weiter zu Phase 2
+        </button>
       </div>
     </div>
   );
@@ -357,9 +453,15 @@ function Phase2({ journey, setJourney, onNext, onBack, setSaveState }) {
           itemKey={(e) => e.id}
         />
       </section>
-      <div className="flex justify-between">
+      <div className="flex justify-between pt-8">
         <button onClick={onBack} className="px-3 py-2 rounded-xl border">Zurück</button>
-        <button onClick={onNext} disabled={!canNext} className="px-3 py-2 rounded-xl bg-primary-500 text-neutrals-0 disabled:opacity-40">Weiter zu Phase 3</button>
+        <button
+          onClick={onNext}
+          disabled={!canNext}
+          className="px-3 py-2 rounded-xl bg-[#1D252A] text-white hover:bg-primary-500 hover:text-neutrals-900 disabled:opacity-40"
+        >
+          Weiter zu Phase 3
+        </button>
       </div>
     </div>
   );
@@ -367,7 +469,13 @@ function Phase2({ journey, setJourney, onNext, onBack, setSaveState }) {
 
 // --- Phase 3 ---------------------------------------------------
 function Phase3({ journey, setJourney, onNext, onBack, setSaveState }) {
-  const top = (journey.top7Ids || [])
+  const topIds =
+    journey.top7Ids && journey.top7Ids.length > 0
+      ? journey.top7Ids
+      : Object.keys(journey.stories || {}).length > 0
+      ? Object.keys(journey.stories)
+      : (journey.ranking || []).slice(0, 7);
+  const top = topIds
     .map((id) => (journey.experiences || []).find((e) => e.id === id))
     .filter(Boolean);
   const stories = journey.stories || {};
@@ -423,43 +531,146 @@ function Phase3({ journey, setJourney, onNext, onBack, setSaveState }) {
           {top.map((e, idx) => (
             <div key={e.id} className="border border-accent-700 rounded-2xl p-3">
               <div className="font-medium mb-2">{idx + 1}. {e.title}</div>
-              <textarea
-                className="w-full rounded-2xl border border-accent-700 p-3 mb-2"
-                rows={2}
+              <VoiceTextarea
                 placeholder="Kontext"
                 value={stories[e.id]?.context || ""}
-                onChange={(ev) => update(e.id, "context", ev.target.value)}
+                onChange={(v) => update(e.id, "context", v)}
               />
-              <textarea
-                className="w-full rounded-2xl border border-accent-700 p-3"
-                rows={2}
+              <VoiceTextarea
                 placeholder="Impact"
                 value={stories[e.id]?.impact || ""}
-                onChange={(ev) => update(e.id, "impact", ev.target.value)}
+                onChange={(v) => update(e.id, "impact", v)}
               />
             </div>
           ))}
         </div>
       </section>
-      <div className="flex justify-between">
+      <div className="flex justify-between pt-8">
         <button onClick={onBack} className="px-3 py-2 rounded-xl border">Zurück</button>
-        <button onClick={handleNext} disabled={!canNext} className="px-3 py-2 rounded-xl bg-primary-500 text-neutrals-0 disabled:opacity-40">Weiter zu Phase 4</button>
+        <button
+          onClick={handleNext}
+          disabled={!canNext}
+          className="px-3 py-2 rounded-xl bg-[#1D252A] text-white hover:bg-primary-500 hover:text-neutrals-900 disabled:opacity-40"
+        >
+          Weiter zu Phase 4
+        </button>
       </div>
     </div>
   );
 }
 
 // --- Phase 4 ---------------------------------------------------
-function Phase4({ onNext, onBack }) {
+function Phase4({ journey, setJourney, onNext, onBack }) {
+  const [analysis, setAnalysis] = useState(journey.analysis || "");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setAnalysis(journey.analysis || "");
+  }, [journey.analysis]);
+
+  const analyze = async () => {
+    try {
+      setLoading(true);
+      const res = await fetch(
+        "https://chrismzke.app.n8n.cloud/webhook-test/c4123f59-47a3-4f9b-a225-126d780722e9",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ userId: journey.userId, journeyId: journey.id }),
+        },
+      );
+      const text = await res.text();
+      try {
+        const data = JSON.parse(text);
+        let md = "";
+        if (Array.isArray(data)) {
+          md = data
+            .map((item) => {
+              if (item && typeof item === "object") {
+                if (typeof item.output === "string") return item.output;
+                return Object.values(item).join("\n\n");
+              }
+              return String(item);
+            })
+            .join("\n\n");
+        } else if (data && typeof data === "object") {
+          md =
+            typeof data.output === "string"
+              ? data.output
+              : Object.values(data)
+                  .map((v) => (typeof v === "string" ? v : String(v)))
+                  .join("\n\n");
+        } else {
+          md = String(data);
+        }
+        setAnalysis(md);
+        const supabase = createClient();
+        await supabase
+          .from("analysis_results")
+          .upsert({ journey_id: journey.id, content: md }, { onConflict: "journey_id" });
+        setJourney((j) => ({ ...j, analysis: md }));
+      } catch {
+        setAnalysis(text);
+        const supabase = createClient();
+        await supabase
+          .from("analysis_results")
+          .upsert({ journey_id: journey.id, content: text }, { onConflict: "journey_id" });
+        setJourney((j) => ({ ...j, analysis: text }));
+      }
+    } catch (e) {
+      console.error(e);
+      setAnalysis("Fehler bei der Analyse");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <div className="space-y-4">
       <section className={cls(cardCls, "p-4")}>
         <h2 className="text-lg font-semibold mb-2">Phase 4: AI‑Analyse</h2>
-        <p className="text-body text-neutrals-600">Die Analyse und Clusterung der Erfahrungen wird später durch einen externen AI‑Service durchgeführt.</p>
+        <p className="text-body text-neutrals-600 mb-3">Die Analyse und Clusterung der Erfahrungen wird später durch einen externen AI‑Service durchgeführt.</p>
+        <button
+          type="button"
+          onClick={analyze}
+          className="px-3 py-2 rounded-xl bg-[#1D252A] text-white hover:bg-primary-500 hover:text-neutrals-900"
+        >
+          {loading ? "Analysiere…" : "Ergebnisse analysieren"}
+        </button>
+        {analysis && (
+          <ReactMarkdown
+            className="mt-4 w-full p-2 border rounded text-neutrals-700"
+            components={{
+              h1: ({ node, ...props }) => (
+                <h1 className="text-h3 font-bold mb-4" {...props} />
+              ),
+              h2: ({ node, ...props }) => (
+                <h2 className="text-h4 font-bold mb-4" {...props} />
+              ),
+              h3: ({ node, ...props }) => (
+                <h3 className="text-h5 font-bold mb-4" {...props} />
+              ),
+              p: ({ node, ...props }) => (
+                <p className="text-body mb-8 last:mb-0" {...props} />
+              ),
+              br: () => <br className="block mb-2" />,
+              li: ({ node, ...props }) => (
+                <li className="ml-4 list-disc text-body mb-2" {...props} />
+              ),
+            }}
+          >
+            {analysis}
+          </ReactMarkdown>
+        )}
       </section>
-      <div className="flex justify-between">
+      <div className="flex justify-between pt-8">
         <button onClick={onBack} className="px-3 py-2 rounded-xl border">Zurück</button>
-        <button onClick={onNext} className="px-3 py-2 rounded-xl bg-primary-500 text-neutrals-0">Weiter zu Phase 5</button>
+        <button
+          onClick={onNext}
+          className="px-3 py-2 rounded-xl bg-[#1D252A] text-white hover:bg-primary-500 hover:text-neutrals-900"
+        >
+          Weiter zu Phase 5
+        </button>
       </div>
     </div>
   );
@@ -503,7 +714,7 @@ function Phase5({ journey, setJourney, onBack, setSaveState }) {
           onChange={(e) => updateField('current', e.target.value)}
         />
       </section>
-      <div className="flex justify-start">
+      <div className="flex justify-start pt-8">
         <button onClick={onBack} className="px-3 py-2 rounded-xl border">Zurück</button>
       </div>
     </div>
@@ -515,7 +726,7 @@ export default function CareerNavigator() {
   const { toasts, push } = useToasts();
   const [step, setStep] = useState(0); // 0=Intro, 1..5 phases
   const [saveState, setSaveState] = useState("idle");
-  const [journey, setJourney] = useState({ id: null, experiences: [], ranking: [], top7Ids: [], stories: {}, profile: {} });
+  const [journey, setJourney] = useState({ id: null, userId: null, experiences: [], ranking: [], top7Ids: [], stories: {}, profile: {}, analysis: "" });
 
   useEffect(() => {
     async function load() {
@@ -529,16 +740,39 @@ export default function CareerNavigator() {
           jRow = newJ;
         }
         const journeyId = jRow.id;
-        const { data: exps } = await supabase.from('experiences').select('id,title,rank,is_top7').eq('journey_id', journeyId);
-        const experiences = (exps || []).map(e => ({ id: e.id, title: e.title }));
-        const ranking = (exps || []).sort((a,b)=> (a.rank||0)-(b.rank||0)).map(e=>e.id);
-        const top7Ids = (exps || []).filter(e=>e.is_top7).map(e=>e.id);
-        const { data: storyRows } = await supabase.from('stories').select('experience_id,context,impact').eq('journey_id', journeyId);
-        const stories = Object.fromEntries((storyRows || []).map(r => [r.experience_id, { context: r.context || '', impact: r.impact || '' }]));
+        const { data: exps } = await supabase
+          .from('experiences')
+          .select('id,title,rank,is_top7')
+          .eq('journey_id', journeyId);
+        const experiences = (exps || []).map((e) => ({ id: e.id, title: e.title }));
+        const ranking = (exps || [])
+          .sort((a, b) => (a.rank || 0) - (b.rank || 0))
+          .map((e) => e.id);
+        let top7Ids = (exps || []).filter((e) => e.is_top7).map((e) => e.id);
+        const { data: storyRows } = await supabase
+          .from('stories')
+          .select('experience_id,context,impact')
+          .eq('journey_id', journeyId);
+        const stories = Object.fromEntries(
+          (storyRows || []).map((r) => [r.experience_id, { context: r.context || '', impact: r.impact || '' }])
+        );
+        if (top7Ids.length === 0 && storyRows && storyRows.length > 0) {
+          top7Ids = storyRows.map((r) => r.experience_id);
+        }
         const { data: profileRow } = await supabase.from('context_profiles').select('notes').eq('journey_id', journeyId).single();
         let profile = {};
-        if (profileRow?.notes) { try { profile = JSON.parse(profileRow.notes); } catch {} }
-        setJourney({ id: journeyId, experiences, ranking, top7Ids, stories, profile });
+        if (profileRow?.notes) {
+          try {
+            profile = JSON.parse(profileRow.notes);
+          } catch {}
+        }
+        const { data: analysisRow } = await supabase
+          .from('analysis_results')
+          .select('content')
+          .eq('journey_id', journeyId)
+          .single();
+        const analysis = analysisRow?.content || "";
+        setJourney({ id: journeyId, userId: user.id, experiences, ranking, top7Ids, stories, profile, analysis });
       } catch (e) {
         console.error(e);
       }
@@ -553,7 +787,7 @@ export default function CareerNavigator() {
       if (!user) return;
       setSaveState('saving');
       const { data: newJ } = await supabase.from('journeys').insert({ user_id: user.id }).select().single();
-      setJourney({ id: newJ.id, experiences: [], ranking: [], top7Ids: [], stories: {}, profile: {} });
+      setJourney({ id: newJ.id, userId: user.id, experiences: [], ranking: [], top7Ids: [], stories: {}, profile: {}, analysis: "" });
       setStep(0);
       push("Zurückgesetzt");
       setSaveState('idle');
@@ -577,7 +811,12 @@ export default function CareerNavigator() {
             <li>Hintergrundinfos</li>
           </ol>
           <div className="flex items-center gap-2">
-            <button onClick={() => setStep(1)} className="px-4 py-2 rounded-xl bg-primary-500 text-neutrals-0">Starten</button>
+            <button
+              onClick={() => setStep(1)}
+              className="px-4 py-2 rounded-xl bg-[#1D252A] text-white hover:bg-primary-500 hover:text-neutrals-900"
+            >
+              Starten
+            </button>
             <button onClick={reset} className="px-4 py-2 rounded-xl border">Zurücksetzen</button>
           </div>
         </section>
@@ -585,7 +824,9 @@ export default function CareerNavigator() {
       {step === 1 && <Phase1 journey={journey} setJourney={setJourney} onNext={() => setStep(2)} setSaveState={setSaveState} />}
       {step === 2 && <Phase2 journey={journey} setJourney={setJourney} onNext={() => setStep(3)} onBack={() => setStep(1)} setSaveState={setSaveState} />}
       {step === 3 && <Phase3 journey={journey} setJourney={setJourney} onNext={() => setStep(4)} onBack={() => setStep(2)} setSaveState={setSaveState} />}
-      {step === 4 && <Phase4 onNext={() => setStep(5)} onBack={() => setStep(3)} />}
+      {step === 4 && (
+        <Phase4 journey={journey} setJourney={setJourney} onNext={() => setStep(5)} onBack={() => setStep(3)} />
+      )}
       {step === 5 && <Phase5 journey={journey} setJourney={setJourney} onBack={() => setStep(4)} setSaveState={setSaveState} />}
       <Toasts toasts={toasts} />
     </Shell>

--- a/app/api/transcribe/route.ts
+++ b/app/api/transcribe/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import OpenAI from "openai";
+
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  try {
+    const formData = await req.formData();
+    const file = formData.get("file") as File | null;
+    const language = formData.get("language") as string | null;
+    if (!file) {
+      return NextResponse.json({ error: "Missing file" }, { status: 400 });
+    }
+    const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    const audioFile = new File([await file.arrayBuffer()], file.name, {
+      type: file.type,
+    });
+    const transcription = await client.audio.transcriptions.create({
+      file: audioFile,
+      model: "whisper-1",
+      language: language || undefined,
+    });
+    return NextResponse.json({ text: transcription.text });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: "Transcription failed" }, { status: 500 });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,23 +11,22 @@
     "check:supabase": "node scripts/checkSupabase.mjs"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.45.0",
     "next": "^15.5.1-canary.24",
+    "openai": "^4.0.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "@supabase/supabase-js": "^2.45.0"
+    "react-markdown": "^9.0.0"
   },
   "devDependencies": {
-    "@types/node": "^24.3.0",
-    "@types/react": "^19.1.12",
-    "@types/react-dom": "^19.1.9",
+    "@types/node": "^20.11.30",
+    "@types/react": "^18.2.45",
+    "@types/react-dom": "^18.2.18",
     "autoprefixer": "10.4.19",
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.4",
     "postcss": "8.4.38",
     "tailwindcss": "3.4.7",
-   "typescript": "^5",
-    "@types/react": "file:types/react",
-    "@types/react-dom": "file:types/react-dom",
-    "@types/node": "file:types/node"
+    "typescript": "^5"
   }
 }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -94,6 +94,18 @@ create table public.analysis (
   top_skills text[] default '{}'
 );
 
+-- Stored Phase 4 analysis in Markdown
+create table public.analysis_results (
+  journey_id uuid primary key references public.journeys(id) on delete cascade,
+  content text,
+  created_at timestamptz default now()
+);
+alter table public.analysis_results enable row level security;
+create policy "analysis_results_owner"
+  on public.analysis_results
+  using (auth.uid() = (select user_id from public.journeys j where j.id = analysis_results.journey_id))
+  with check (auth.uid() = (select user_id from public.journeys j where j.id = analysis_results.journey_id));
+
 -- Context profile
 create table public.context_profiles (
   journey_id uuid primary key references public.journeys(id) on delete cascade,


### PR DESCRIPTION
## Summary
- add voice-enabled textareas with microphone control that record, transcribe via Whisper, and let users append or delete segments
- create `/api/transcribe` route using OpenAI to convert uploaded audio to text
- analyze saved experiences through n8n using only user and journey IDs, rendering the webhook result as Markdown
- ensure Phase 3 always shows saved top-seven stories by deriving them from stored stories when ranking data is missing
- replace local type stubs with published `@types` packages
- parse n8n webhook arrays and display their `output` field as formatted Markdown in Phase 4
- style Phase 4 Markdown headings with tailored classes so headers render correctly
- expand Phase 4 paragraph spacing so breaks are wider than single line jumps
- persist Phase 4 AI analysis by saving the markdown to Supabase and reloading it on revisit
- add `analysis_results` table to store per-journey analysis text with row-level security

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd79d1c6048322b5ebc5e9f4c0957c