### PR TITLE
Fix sidebar label and login/logout visibility

### DIFF
--- a/app/components/navItems.ts
+++ b/app/components/navItems.ts
@@ -1,0 +1,25 @@
+export type NavItem = {
+  label: string;
+  iconPath: string;
+  href?: string;
+};
+
+export const navItems: NavItem[] = [
+  {
+    label: "Home",
+    iconPath: "M3 12l9-7 9 7v8a1 1 0 01-1 1h-5v-6H9v6H4a1 1 0 01-1-1v-8z",
+    href: "/start",
+  },
+  {
+    label: "Resources",
+    iconPath: "M4 6h16v2H4V6zm0 5h16v2H4v-2zm0 5h16v2H4v-2z",
+  },
+  {
+    label: "Quick Test",
+    iconPath: "M12 2a10 10 0 100 20 10 10 0 000-20zm1 5h-2v6l5 3 .9-1.5-3.9-2.3V7z",
+  },
+  {
+    label: "Help",
+    iconPath: "M12 2a10 10 0 100 20 10 10 0 000-20zm0 15a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm0-2a1 1 0 01-1-1c0-2 3-2 3-5a3 3 0 10-6 0H6a6 6 0 1112 0c0 4-4 4-4 6a1 1 0 01-1 1z",
+  },
+];

--- a/app/start/fast/background/page.tsx
+++ b/app/start/fast/background/page.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { saveProgress } from "@/lib/progress";
+
+export default function BackgroundSnapshotPage() {
+  const router = useRouter();
+  const [status, setStatus] = useState("");
+  const [role, setRole] = useState("");
+  const [education, setEducation] = useState("");
+  const [aspiration, setAspiration] = useState("");
+
+  const handleNext = () => {
+    saveProgress({ track: "fast", stepId: "background", updatedAt: Date.now() });
+    router.push("/start/fast/processing");
+  };
+
+  return (
+    <main className="mx-auto max-w-xl px-4 py-8">
+      <h1 className="font-display text-neutrals-900 text-[24px] md:text-[28px] font-semibold mb-6">Background Snapshot</h1>
+      <div className="space-y-4">
+        <label className="block">
+          <span className="text-small text-neutrals-700">Current status</span>
+          <select
+            value={status}
+            onChange={(e) => setStatus(e.target.value)}
+            className="mt-1 w-full rounded-xl border border-neutrals-300 p-2"
+          >
+            <option value="" disabled>Select status</option>
+            <option>student</option>
+            <option>early-career</option>
+            <option>mid-career</option>
+          </select>
+        </label>
+        <label className="block">
+          <span className="text-small text-neutrals-700">Current/last role or study field</span>
+          <input
+            type="text"
+            value={role}
+            onChange={(e) => setRole(e.target.value)}
+            className="mt-1 w-full rounded-xl border border-neutrals-300 p-2"
+          />
+        </label>
+        <label className="block">
+          <span className="text-small text-neutrals-700">Highest education level (optional)</span>
+          <select
+            value={education}
+            onChange={(e) => setEducation(e.target.value)}
+            className="mt-1 w-full rounded-xl border border-neutrals-300 p-2"
+          >
+            <option value="">Select level</option>
+            <option>High school</option>
+            <option>Bachelor's</option>
+            <option>Master's</option>
+            <option>Doctorate</option>
+          </select>
+        </label>
+        <label className="block">
+          <span className="text-small text-neutrals-700">If I could explore anything next, it would be…</span>
+          <input
+            type="text"
+            value={aspiration}
+            onChange={(e) => setAspiration(e.target.value)}
+            className="mt-1 w-full rounded-xl border border-neutrals-300 p-2"
+          />
+        </label>
+      </div>
+      <button
+        type="button"
+        onClick={handleNext}
+        className="mt-6 rounded-full bg-primary-500 text-[#2C2C2C] px-6 py-2 text-small font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary-500/60"
+      >
+        Continue
+      </button>
+    </main>
+  );
+}

--- a/app/start/fast/page.tsx
+++ b/app/start/fast/page.tsx
@@ -1,20 +1,29 @@
 "use client";
 
+import Link from "next/link";
+import { useEffect } from "react";
 import { saveProgress } from "@/lib/progress";
 
-export default function FastTrackPlaceholder() {
+export default function FastScanWelcome() {
+  useEffect(() => {
+    saveProgress({ track: "fast", stepId: "welcome", updatedAt: Date.now() });
+  }, []);
+
   return (
-    <main className="min-h-screen px-4 py-8">
-      <h1 className="font-display text-neutrals-900 text-[28px] md:text-[32px] font-semibold">Fast Track (placeholder)</h1>
-      <p className="mt-2 text-neutrals-700">This flow is not implemented yet.</p>
-      <button
-        type="button"
-        onClick={() => saveProgress({ track: "fast", stepId: "intro", updatedAt: Date.now() })}
-        className="mt-6 rounded-full bg-primary-500 text-[#2C2C2C] px-4 py-2 text-small font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary-500/60"
-        aria-label="Save demo progress"
+    <main className="min-h-screen px-4 py-8 md:py-12 flex flex-col items-center justify-center text-center">
+      <h1 className="font-display text-neutrals-900 text-[28px] md:text-[32px] font-semibold">
+        Welcome to your Career Fast Scan
+      </h1>
+      <p className="mt-4 max-w-xl text-neutrals-700">
+        In the next 10 minutes, you’ll get a personalized snapshot of your strengths, values, and potential career development paths. Just answer a few quick prompts — we’ll do the rest.
+      </p>
+      <Link
+        href="/start/fast/prompts"
+        className="mt-8 rounded-full bg-primary-500 text-[#2C2C2C] px-6 py-3 text-small font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary-500/60"
+        aria-label="Start Fast Scan"
       >
-        Save demo progress
-      </button>
+        Start My Fast Scan
+      </Link>
     </main>
   );
 }

--- a/app/start/fast/processing/page.tsx
+++ b/app/start/fast/processing/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { saveProgress } from "@/lib/progress";
+
+export default function FastProcessingPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    saveProgress({ track: "fast", stepId: "processing", updatedAt: Date.now() });
+    const t = setTimeout(() => router.push("/start/fast/results"), 2000);
+    return () => clearTimeout(t);
+  }, [router]);
+
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center px-4 py-8 text-center">
+      <div className="h-16 w-16 rounded-full border-4 border-primary-500 border-t-transparent animate-spin mb-6" />
+      <p className="max-w-md text-neutrals-700">
+        Analyzing your responses… Matching your themes with career paths in demand…
+      </p>
+    </main>
+  );
+}

--- a/app/start/fast/prompts/page.tsx
+++ b/app/start/fast/prompts/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { saveProgress } from "@/lib/progress";
+
+const prompts = [
+  "Describe a moment where you felt really engaged or ‘in flow.’",
+  "What type of tasks give you energy instead of draining it?",
+  "What matters most to you at work — e.g. creativity, impact, independence?",
+];
+
+export default function FastPromptsPage() {
+  const router = useRouter();
+  const [step, setStep] = useState(0);
+  const [answers, setAnswers] = useState<string[]>(["", "", ""]);
+
+  const handleNext = () => {
+    if (step < prompts.length - 1) {
+      setStep(step + 1);
+    } else {
+      saveProgress({ track: "fast", stepId: "prompts", updatedAt: Date.now() });
+      router.push("/start/fast/background");
+    }
+  };
+
+  return (
+    <main className="mx-auto max-w-xl px-4 py-8">
+      <h1 className="font-display text-neutrals-900 text-[24px] md:text-[28px] font-semibold mb-6">
+        Quick Motivational Prompts
+      </h1>
+      <p className="text-neutrals-700 mb-4">{prompts[step]}</p>
+      <textarea
+        value={answers[step]}
+        onChange={(e) => {
+          const next = answers.slice();
+          next[step] = e.target.value;
+          setAnswers(next);
+        }}
+        rows={4}
+        className="w-full rounded-xl border border-neutrals-300 p-3"
+      />
+      <button
+        type="button"
+        onClick={handleNext}
+        disabled={!answers[step].trim()}
+        className="mt-6 rounded-full bg-primary-500 text-[#2C2C2C] px-6 py-2 text-small font-semibold disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary-500/60"
+      >
+        {step < prompts.length - 1 ? "Next" : "Continue"}
+      </button>
+    </main>
+  );
+}

--- a/app/start/fast/results/page.tsx
+++ b/app/start/fast/results/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+import { saveProgress } from "@/lib/progress";
+
+export default function FastResultsPage() {
+  useEffect(() => {
+    saveProgress({ track: "fast", stepId: "results", updatedAt: Date.now() });
+  }, []);
+
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-8 space-y-8">
+      <section>
+        <h2 className="font-display text-[20px] font-semibold mb-4">Top 3 Motivational Themes</h2>
+        <ul className="space-y-3">
+          <li className="rounded-xl bg-neutrals-100 p-4">Analytical Problem-Solving — you thrive when breaking down complex challenges.</li>
+          <li className="rounded-xl bg-neutrals-100 p-4">Collaboration &amp; Teamwork — working with others energizes you.</li>
+          <li className="rounded-xl bg-neutrals-100 p-4">Independence — you value autonomy and owning your projects.</li>
+        </ul>
+      </section>
+      <section>
+        <h2 className="font-display text-[20px] font-semibold mb-4">Suggested Career Paths</h2>
+        <ul className="space-y-3">
+          <li className="rounded-xl bg-neutrals-100 p-4"><strong>Data Analyst</strong> — €52k avg. Uses problem-solving and data skills to support business decisions.</li>
+          <li className="rounded-xl bg-neutrals-100 p-4"><strong>Product Designer</strong> — €58k avg. Combines creativity and collaboration to craft user-centered products.</li>
+          <li className="rounded-xl bg-neutrals-100 p-4"><strong>Project Manager</strong> — €60k avg. Leads teams and drives outcomes with structured planning.</li>
+        </ul>
+      </section>
+      <section>
+        <h2 className="font-display text-[20px] font-semibold mb-4">Micro Action Ideas</h2>
+        <ul className="space-y-2 list-disc pl-5 text-neutrals-700">
+          <li>Try a 1-hour SQL basics course</li>
+          <li>Shadow a product manager at your company</li>
+          <li>Join a local meetup focused on design thinking</li>
+        </ul>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- ensure sidebar labels and logout text render consistently across pages
- hide user email when sidebar is collapsed
- show login option in sidebar when unauthenticated
- centralize navigation items in config to keep the nav bar consistent
- keep sidebar fixed to the viewport and non-scrollable
- add fast scan workflow with welcome, prompts, background, processing, and results pages

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3d8eb55dc8322a91d88ee8ea4cbf9