### PR TITLE
Rename voice recording screen

### DIFF
--- a/app/start/fast/page.tsx
+++ b/app/start/fast/page.tsx
@@ -195,8 +195,25 @@ export default function FastTrack() {
             <section className="rounded-3xl border border-neutrals-200/60 bg-neutrals-0/60 backdrop-blur-md shadow-elevation2 p-6">
               <h2 className="text-lg font-semibold mb-2">Schritt 1: Basisinfos</h2>
               <p className="text-neutrals-700 mb-4">Statt Tippen: per Stimme aufnehmen. Jede Eingabe öffnet ein Pop‑up zur Sprachaufnahme.</p>
+              <button
+                type="button"
+                onClick={() => router.push("/start/fast/voice")}
+                className="w-full mb-6 rounded-2xl border border-primary-200 bg-primary-50 px-5 py-4 text-left shadow-sm transition hover:border-primary-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+                aria-label="Sprachaufnahme öffnen"
+              >
+                <div className="flex items-center justify-between gap-4">
+                  <div className="space-y-1">
+                    <p className="text-xs font-semibold uppercase tracking-[0.25em] text-primary-600">Sprach-Coach</p>
+                    <p className="text-xl font-semibold text-[#1D252A]">Aufnahme starten</p>
+                    <p className="text-sm text-[#1D252A]/70">
+                      Öffne den Vollbildmodus, um deine Stimme bequem aufzunehmen.
+                    </p>
+                  </div>
+                  <span aria-hidden="true" className="text-3xl text-primary-600">›</span>
+                </div>
+              </button>
               <div className="space-y-4">
-                {(([ 
+                {(([
                   { key: "background", label: "Ausbildung und beruflicher Hintergrund" },
                   { key: "current", label: "Aktuelle Rolle" },
                   { key: "goals", label: "Ziele und Interessen" },

--- a/app/start/fast/voice/page.tsx
+++ b/app/start/fast/voice/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+function cls(...values: (string | false | null | undefined)[]) {
+  return values.filter(Boolean).join(" ");
+}
+
+export default function VoiceCoachPage() {
+  const router = useRouter();
+  const [recording, setRecording] = useState(false);
+
+  return (
+    <main className="min-h-screen bg-[#0B1218] text-white flex flex-col">
+      <div
+        className="flex-1 flex flex-col items-center justify-between w-full max-w-sm mx-auto px-6 pt-12 pb-10"
+        style={{ paddingBottom: "calc(2.5rem + env(safe-area-inset-bottom, 0px))" }}
+      >
+        <header className="w-full text-center space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.35em] text-white/60">Sprach-Coach</p>
+          <h1 className="text-3xl font-semibold">Sprachaufnahme</h1>
+          <p className="text-sm text-white/70">
+            Hier kannst du deine Stimme aufnehmen. Tippe auf den Kreis, um zu starten, und erneut, um die Aufnahme zu pausieren.
+          </p>
+        </header>
+
+        <div className="flex-1 flex flex-col items-center justify-center gap-6">
+          <div className="relative flex items-center justify-center">
+            <span
+              aria-hidden="true"
+              className={cls(
+                "absolute h-52 w-52 rounded-full bg-primary-500/20 blur-xl transition-opacity duration-300",
+                recording ? "opacity-100" : "opacity-0",
+              )}
+            />
+            <button
+              type="button"
+              aria-pressed={recording}
+              onClick={() => setRecording((prev) => !prev)}
+              className={cls(
+                "relative flex h-44 w-44 items-center justify-center rounded-full text-base font-semibold transition-all duration-300 shadow-elevation4 focus:outline-none focus-visible:ring-4 focus-visible:ring-white/40",
+                recording ? "bg-primary-500 text-[#1D252A] scale-105" : "bg-white/95 text-[#1D252A]",
+              )}
+            >
+              {recording ? "Pause" : "Start"}
+            </button>
+          </div>
+          <p className="text-sm text-white/70">{recording ? "Aufnahme läuft…" : "Tippe auf den Kreis, um loszulegen."}</p>
+        </div>
+
+        <div className="w-full grid grid-cols-2 gap-4">
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="h-12 rounded-full border border-white/30 text-sm font-semibold text-white transition hover:border-white/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+          >
+            Abbrechen
+          </button>
+          <button
+            type="button"
+            className="h-12 rounded-full bg-primary-500 text-sm font-semibold text-[#1D252A] transition hover:bg-primary-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-300"
+            onClick={() => setRecording(false)}
+          >
+            Senden
+          </button>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- rename the fast track voice recording entry point and route to a generic voice page
- update the full-screen recording experience to use neutral Sprach-Coach naming

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d56a7c3aa88322a1136e2323487be2